### PR TITLE
Add `notification_trigger` resource to trigger notifications

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/). Note that
 
 ## Unreleased
 
+* [FEATURE] `notification_trigger` resource to trigger notifications
 * [FEATURE] Helper for the ingenerator_project_name which must be defined in a role
   before use
 * [FEATURE] Add simple attribute helpers for common cases where we want to reject

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 inGenerator Helpers cookbook
 ============================
-[![Build Status](https://travis-ci.org/ingenerator/chef-ingenerator-helpers.png?branch=master)](https://travis-ci.org/ingenerator/chef-ingenerator-helpers)
+[![Build Status](https://travis-ci.org/ingenerator/chef-ingenerator-helpers.png?branch=1.x)](https://travis-ci.org/ingenerator/chef-ingenerator-helpers)
 
 The `ingenerator-helpers` cookbook provides simple helpers and reusable code blocks for
 our various chef cookbooks.
@@ -70,6 +70,21 @@ if node['service']['do_thing']
 end
 ```
 
+
+Custom resources
+----------------
+
+## notification_trigger
+
+Sometimes you just want to queue a delayed notification to cause some action to
+happen right at the end of the chef run every time. There's probably an official
+way to do that, but since I can't find one you can do this:
+
+```
+notification_trigger "Make a thing happen" do
+  notifies :restart, 'service[brain]', :delayed
+end
+```
 
 Installation
 ------------

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,0 +1,5 @@
+if defined?(ChefSpec)
+  def queue_notification_trigger(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:notification_trigger, :queue, resource_name)
+  end
+end

--- a/resources/notification_trigger.rb
+++ b/resources/notification_trigger.rb
@@ -1,0 +1,21 @@
+# notification_trigger is a no-op resource that just provides a place to manually
+# queue delayed notifications, for example for a service that should always be
+# reloaded after a provisioning run.
+#
+# Use it like:
+#
+#   notification_trigger 'Flush opcode cache' do
+#     notifies :reload, 'service[apache2]', :delayed
+#   end
+#
+resource_name :notification_trigger
+
+property :name, String, name_property: true
+
+default_action :queue
+
+action :queue do
+  # Literally all we have to do is pretend this resource did something so chef
+  # triggers its notifications
+  new_resource.updated_by_last_action(true)
+end

--- a/spec/unit/recipes/notification_trigger_spec.rb
+++ b/spec/unit/recipes/notification_trigger_spec.rb
@@ -1,0 +1,30 @@
+require "spec_helper"
+
+context "test_notification_trigger" do
+
+  let(:chef_conf) do ChefSpec::SoloRunner.new(
+      cookbook_path: %w(./test/cookbooks ../),
+      step_into:     %w(notification_trigger),
+      platform:      'ubuntu',
+      version:       '14.04'
+    )
+  end
+
+  context 'when set to notify resource' do
+    cached(:chef_run) do
+      chef_conf.converge('test_helpers::notification_trigger')
+    end
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+
+    it 'sets the expected notification' do
+      expect(chef_run).to queue_notification_trigger('Reload apache')
+    end
+
+    it 'triggers the expected action on the resource' do
+      expect(chef_run).to reload_service 'apache2'
+    end
+  end
+end

--- a/test/cookbooks/test_helpers/metadata.rb
+++ b/test/cookbooks/test_helpers/metadata.rb
@@ -1,0 +1,9 @@
+name             'test_helpers'
+maintainer       'The authors'
+maintainer_email 'me@here.mail'
+license          'all'
+description      'cookbook for unit tests etc of custom resources'
+long_description 'cookbook for unit tests etc of custom resources'
+version          '0.1.0'
+
+depends 'ingenerator-helpers'

--- a/test/cookbooks/test_helpers/recipes/notification_trigger.rb
+++ b/test/cookbooks/test_helpers/recipes/notification_trigger.rb
@@ -1,0 +1,7 @@
+service 'apache2' do
+  action :nothing
+end
+
+notification_trigger 'Reload apache' do
+  notifies :reload, 'service[apache2]', :delayed
+end


### PR DESCRIPTION
Because there doesn't seem to be any better way to say I always want
a thing to run right at the end of the chef run.